### PR TITLE
Always Set Project Dir as Working Dir

### DIFF
--- a/down-develop.sh
+++ b/down-develop.sh
@@ -3,7 +3,13 @@
 export COMPOSE_PROJECT=codex-develop
 
 CODEX_REPOS=${CODEX_REPOS:-"codex-keycloak,codex-feasibility-gui,codex-feasibility-backend,codex-flare"}
-baseDir=$(pwd)
+
+readlink "$0" > /dev/null
+if [ $? -ne 0 ]; then
+  baseDir=$(dirname "$0")
+else
+  baseDir=$(dirname "$(readlink "$0")")
+fi
 
 
 for repoName in ${CODEX_REPOS//,/ }

--- a/gitUpdate.sh
+++ b/gitUpdate.sh
@@ -2,7 +2,13 @@
 
 gitBase="https://github.com/num-codex/"
 repos=("codex-feasibility-gui" "codex-feasibility-backend" "codex-keycloak" "codex-processes-ap2" "codex-aktin-broker" "codex-sq2cql" "num-knoten" "broker" "codex-flare")
-baseDir=$(pwd)
+
+readlink "$0" > /dev/null
+if [ $? -ne 0 ]; then
+  baseDir=$(dirname "$0")
+else
+  baseDir=$(dirname "$(readlink "$0")")
+fi
 
 echo "****updating base repo Develop****"
 git pull

--- a/rebuild-develop.sh
+++ b/rebuild-develop.sh
@@ -3,7 +3,13 @@
 export COMPOSE_PROJECT=codex-develop
 
 CODEX_REPOS=${CODEX_REPOS:-"codex-keycloak,codex-feasibility-gui,codex-feasibility-backend,codex-flare"}
-baseDir=$(pwd)
+
+readlink "$0" > /dev/null
+if [ $? -ne 0 ]; then
+  baseDir=$(dirname "$0")
+else
+  baseDir=$(dirname "$(readlink "$0")")
+fi
 
 
 for repoName in ${CODEX_REPOS//,/ }

--- a/start-develop.sh
+++ b/start-develop.sh
@@ -2,8 +2,14 @@
 
 export COMPOSE_PROJECT=codex-develop
 
-baseDir=$(pwd)
 CODEX_REPOS=${CODEX_REPOS:-"codex-keycloak,codex-feasibility-gui,codex-feasibility-backend,codex-flare"}
+
+readlink "$0" > /dev/null
+if [ $? -ne 0 ]; then
+  baseDir=$(dirname "$0")
+else
+  baseDir=$(dirname "$(readlink "$0")")
+fi
 
 export CODEX_CONCEPT_TREE_PATH=${CODEX_CONCEPT_TREE_PATH:-"$baseDir/ontology/codex-code-tree.json"}
 export CODEX_TERM_CODE_MAPPING_PATH=${CODEX_TERM_CODE_MAPPING_PATH:-"$baseDir/ontology/term-code-mapping.json"}

--- a/stop-develop.sh
+++ b/stop-develop.sh
@@ -3,7 +3,13 @@
 export COMPOSE_PROJECT=codex-develop
 
 CODEX_REPOS=${CODEX_REPOS:-"codex-keycloak,codex-feasibility-gui,codex-feasibility-backend,codex-flare"}
-baseDir=$(pwd)
+
+readlink "$0" > /dev/null
+if [ $? -ne 0 ]; then
+  baseDir=$(dirname "$0")
+else
+  baseDir=$(dirname "$(readlink "$0")")
+fi
 
 
 for repoName in ${CODEX_REPOS//,/ }


### PR DESCRIPTION
Replaces any calls to pwd with a routine that
sets baseDir to the location of any affected
invoked script. This change avoids changes to
directories outside of this project when its
scripts are invoked from outside of the project
directory.

Currently only follows a single symlink since
MacOS is missing the -f flag necessary for
following multiple links.

Resolves #3.